### PR TITLE
:sparkles:  add: api client to vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Upload: 13.56 Mbit/s
 
 ### ご注意
 
-- 配布された `Raspberry Pi` には `git` が入ってないので `sudo apt install -y git` を実行してください。必要に応じて`sudo apt-get update`も行ってください。
+- 配布された `Raspberry Pi` には `git` が入ってないので `sudo apt install -y git` を実行してください。必要に応じて `sudo apt update` も行ってください。
 - `ssh` などではなく [PiZeroWebSerialConsole](https://chirimen.org/PiZeroWebSerialConsole/PiZeroWebSerialConsole.html) を利用している場合などで `Raspberry Pi` の OTG 用 USB ポート(Chirimen で操作する際に使う方)からしか給電していない場合は OTG 用ポートに加えて電源用 USB ポートからも給電してください。(手順の途中で PC 以外のシリアルデータ通信が必要になるデバイスの接続を要するため)
 - `WiFi` などはセットアップ済である前提です。
 - 配布された `Raspberry Pi Zero WH` に `USB Hub (MicroB to USB-A * 2つ以上)` `USB Audio Interface` と `USB-A to TypeC ケーブル` を接続してください。(`USB-A to TypeC ケーブル` についてはスマホ側のインターフェースに応じて変更してください。)(或いは `Raspberry Pi 4` などを利用してください。)

--- a/db.example.json
+++ b/db.example.json
@@ -1,50 +1,53 @@
 {
-  "d1": {
-    "active": true,
-    "about": "選択済みタオル枚数が減ったとき(箱の天井との距離が220以上のとき)",
-    "threshold": 220,
-    "over_or_less": "over"
-  },
-  "d2": {
-    "active": true,
-    "about": "選択済みタオル枚数が減ったとき(タオル重量が360以下のとき)",
-    "threshold": 360,
-    "over_or_less": "less"
-  },
-  "d3": {
-    "active": false,
-    "about": "",
-    "threshold": 0,
-    "over_or_less": ""
-  },
-  "d4": {
-    "active": false,
-    "about": "",
-    "threshold": 0,
-    "over_or_less": ""
-  },
-  "d5": {
-    "active": false,
-    "about": "",
-    "threshold": 0,
-    "over_or_less": ""
-  },
-  "d6": {
-    "active": false,
-    "about": "",
-    "threshold": 0,
-    "over_or_less": ""
-  },
-  "d7": {
-    "active": false,
-    "about": "",
-    "threshold": 0,
-    "over_or_less": ""
-  },
-  "d8": {
-    "active": false,
-    "about": "",
-    "threshold": 0,
-    "over_or_less": ""
+  "lang": "jp",
+  "sensor": {
+    "d1": {
+      "active": true,
+      "about": "選択済みタオル枚数が減ったとき(箱の天井との距離が220以上のとき)",
+      "threshold": 220,
+      "over_or_less": "over"
+    },
+    "d2": {
+      "active": true,
+      "about": "選択済みタオル枚数が減ったとき(タオル重量が360以下のとき)",
+      "threshold": 360,
+      "over_or_less": "less"
+    },
+    "d3": {
+      "active": false,
+      "about": "",
+      "threshold": 0,
+      "over_or_less": ""
+    },
+    "d4": {
+      "active": false,
+      "about": "",
+      "threshold": 0,
+      "over_or_less": ""
+    },
+    "d5": {
+      "active": false,
+      "about": "",
+      "threshold": 0,
+      "over_or_less": ""
+    },
+    "d6": {
+      "active": false,
+      "about": "",
+      "threshold": 0,
+      "over_or_less": ""
+    },
+    "d7": {
+      "active": false,
+      "about": "",
+      "threshold": 0,
+      "over_or_less": ""
+    },
+    "d8": {
+      "active": false,
+      "about": "",
+      "threshold": 0,
+      "over_or_less": ""
+    }
   }
 }

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -2,57 +2,64 @@ import fs from 'fs';
 import { DB_PATH } from '../constants/constant';
 
 export const CONTENTS = {
-  d1: {
-    active: false,
-    about: '',
-    threshold: 0,
-    over_or_less: '',
-  },
-  d2: {
-    active: false,
-    about: '',
-    threshold: 0,
-    over_or_less: '',
-  },
-  d3: {
-    active: false,
-    about: '',
-    threshold: 0,
-    over_or_less: '',
-  },
-  d4: {
-    active: false,
-    about: '',
-    threshold: 0,
-    over_or_less: '',
-  },
-  d5: {
-    active: false,
-    about: '',
-    threshold: 0,
-    over_or_less: '',
-  },
-  d6: {
-    active: false,
-    about: '',
-    threshold: 0,
-    over_or_less: '',
-  },
-  d7: {
-    active: false,
-    about: '',
-    threshold: 0,
-    over_or_less: '',
-  },
-  d8: {
-    active: false,
-    about: '',
-    threshold: 0,
-    over_or_less: '',
+  lang: 'jp',
+  sensor: {
+    d1: {
+      active: false,
+      about: '',
+      threshold: 0,
+      over_or_less: '',
+    },
+    d2: {
+      active: false,
+      about: '',
+      threshold: 0,
+      over_or_less: '',
+    },
+    d3: {
+      active: false,
+      about: '',
+      threshold: 0,
+      over_or_less: '',
+    },
+    d4: {
+      active: false,
+      about: '',
+      threshold: 0,
+      over_or_less: '',
+    },
+    d5: {
+      active: false,
+      about: '',
+      threshold: 0,
+      over_or_less: '',
+    },
+    d6: {
+      active: false,
+      about: '',
+      threshold: 0,
+      over_or_less: '',
+    },
+    d7: {
+      active: false,
+      about: '',
+      threshold: 0,
+      over_or_less: '',
+    },
+    d8: {
+      active: false,
+      about: '',
+      threshold: 0,
+      over_or_less: '',
+    },
   },
 };
+export const SENSOR_NAMES = Object.keys(CONTENTS.sensor);
 
-export const CONTENT_NAMES = Object.keys(CONTENTS);
+export const LANG = {
+  JP: 'jp',
+  EK: 'ek',
+} as const;
 
 export const COMPARISON = {
   OVER: 'over',
@@ -68,14 +75,15 @@ export const initFileIfNotExists = () => {
 
 export const reflectFromFile = () => {
   const draft = JSON.parse(fs.readFileSync(DB_PATH, 'utf8'));
-  CONTENTS.d1 = draft.d1;
-  CONTENTS.d2 = draft.d2;
-  CONTENTS.d3 = draft.d3;
-  CONTENTS.d4 = draft.d4;
-  CONTENTS.d5 = draft.d5;
-  CONTENTS.d6 = draft.d6;
-  CONTENTS.d7 = draft.d7;
-  CONTENTS.d8 = draft.d8;
+  CONTENTS.lang = draft.lang;
+  CONTENTS.sensor.d1 = draft.sensor.d1;
+  CONTENTS.sensor.d2 = draft.sensor.d2;
+  CONTENTS.sensor.d3 = draft.sensor.d3;
+  CONTENTS.sensor.d4 = draft.sensor.d4;
+  CONTENTS.sensor.d5 = draft.sensor.d5;
+  CONTENTS.sensor.d6 = draft.sensor.d6;
+  CONTENTS.sensor.d7 = draft.sensor.d7;
+  CONTENTS.sensor.d8 = draft.sensor.d8;
 };
 
 export const saveToFile = (draft?: typeof CONTENTS) => {

--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nameless-housework-notification",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.3.1",
         "core-js": "^3.8.3",
         "element-plus": "^2.2.28",
         "register-service-worker": "^1.7.2",
@@ -3809,6 +3810,11 @@
       "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
       "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -3861,6 +3867,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.1.tgz",
+      "integrity": "sha512-78pWJsQTceInlyaeBQeYZ/QgZeWS8hGeKiIJiDKQe3hEyBb7sEMq0K4gjx+Va6WHTYO4zI/RRl8qGRzn0YMadA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-loader": {
@@ -4458,6 +4474,17 @@
       "resolved": "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha1-zfBE9HrUGg9LVrOg1bTm4aLVp5g= sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "7.2.0",
@@ -5159,6 +5186,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -6316,7 +6351,6 @@
       "version": "1.15.2",
       "resolved": "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz",
       "integrity": "sha1-tGCGQUS6Y/JoEJbydMTlcCbaLBM= sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -6405,6 +6439,19 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -8160,7 +8207,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A= sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8169,7 +8215,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo= sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -9612,6 +9657,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
@@ -15326,6 +15376,11 @@
       "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
       "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg=="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -15351,6 +15406,16 @@
       "resolved": "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha1-kvlWFlAQadB9EO2y/DfT4cZRI7c= sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
+    },
+    "axios": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.1.tgz",
+      "integrity": "sha512-78pWJsQTceInlyaeBQeYZ/QgZeWS8hGeKiIJiDKQe3hEyBb7sEMq0K4gjx+Va6WHTYO4zI/RRl8qGRzn0YMadA==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "babel-loader": {
       "version": "8.3.0",
@@ -15790,6 +15855,14 @@
       "resolved": "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha1-zfBE9HrUGg9LVrOg1bTm4aLVp5g= sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "commander": {
       "version": "7.2.0",
@@ -16288,6 +16361,11 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -17194,8 +17272,7 @@
     "follow-redirects": {
       "version": "1.15.2",
       "resolved": "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha1-tGCGQUS6Y/JoEJbydMTlcCbaLBM= sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "dev": true
+      "integrity": "sha1-tGCGQUS6Y/JoEJbydMTlcCbaLBM= sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -17244,6 +17321,16 @@
           "integrity": "sha1-ofzMBrWNth/XpF2i2kT186Pme6I= sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
           "dev": true
         }
+      }
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -18554,14 +18641,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A= sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A= sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo= sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -19580,6 +19665,11 @@
           "dev": true
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "pseudomap": {
       "version": "1.0.2",

--- a/vue/package.json
+++ b/vue/package.json
@@ -8,6 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "axios": "^1.3.1",
     "core-js": "^3.8.3",
     "element-plus": "^2.2.28",
     "register-service-worker": "^1.7.2",

--- a/vue/src/api/client.ts
+++ b/vue/src/api/client.ts
@@ -1,0 +1,86 @@
+import axios from 'axios';
+
+type OverOrLess = 'over' | 'less';
+
+export type GetAllRes = {
+  lang: 'jp' | 'en';
+  sensor: {
+    d1: {
+      active: boolean;
+      about: string;
+      threshold: number;
+      over_or_less: OverOrLess;
+    };
+    d2: {
+      active: boolean;
+      about: string;
+      threshold: number;
+      over_or_less: OverOrLess;
+    };
+    d3: {
+      active: boolean;
+      about: string;
+      threshold: number;
+      over_or_less: OverOrLess;
+    };
+    d4: {
+      active: boolean;
+      about: string;
+      threshold: number;
+      over_or_less: OverOrLess;
+    };
+    d5: {
+      active: boolean;
+      about: string;
+      threshold: number;
+      over_or_less: OverOrLess;
+    };
+    d6: {
+      active: boolean;
+      about: string;
+      threshold: number;
+      over_or_less: OverOrLess;
+    };
+    d7: {
+      active: boolean;
+      about: string;
+      threshold: number;
+      over_or_less: OverOrLess;
+    };
+    d8: {
+      active: boolean;
+      about: string;
+      threshold: number;
+      over_or_less: OverOrLess;
+    };
+  };
+};
+
+export class Client {
+  readonly endpoint: string;
+
+  /**
+   * @param {string} endpoint ex: https://xxx.ngrok.io
+   */
+  constructor(endpoint: string) {
+    this.endpoint = endpoint;
+  }
+
+  async getAll() {
+    return (await axios.get<GetAllRes>(`${this.endpoint}/api/notification/config`)).data;
+  }
+
+  async updateSensor(ops: {
+    name: keyof GetAllRes['sensor'];
+    active: boolean;
+    about: string;
+    threshold: number;
+    over_or_less: OverOrLess;
+  }) {
+    return (
+      await axios.put<GetAllRes>(
+        `${this.endpoint}'/api/notification/config/sensor/${ops.name}/${ops.active}/:${ops.threshold}/:${ops.over_or_less}/:${ops.about}`
+      )
+    ).data;
+  }
+}

--- a/vue/src/views/HomeView.vue
+++ b/vue/src/views/HomeView.vue
@@ -1,14 +1,20 @@
 <template>
   <div :id="$style.parent">
     <h1>Nameless Housework</h1>
-    <p>
+    <p :class="$style.left">
       <a href="https://webiotmakers.connpass.com/event/268756/">
         東京開催！2022年度 Web×IoT メイカーズチャレンジ PLUS【講習会&ハッカソン】
       </a>
       のFチームが<br />開発した家事が発生したことを教えてくれるシステムです！
     </p>
 
-    <div :class="$style.setting" v-for="(data, key, index) in state.sensor" :key="key">
+    <div v-if="!ENDPOINT" :class="$style.left">
+      <p>
+        ⚠ 通信に必要なパラメータがありません。Raspberry Pi 等の画面に表示された QR
+        コードをスキャンしてアクセスしてください。
+      </p>
+    </div>
+    <div v-else :class="$style.setting" v-for="(data, key, index) in state.sensor" :key="key">
       <el-card>
         <template #header>
           <div class="card-header">
@@ -45,19 +51,20 @@
           </el-col>
           <el-col :span="4" @click="save">
             <el-icon :size="30"><UploadFilled /></el-icon><br />
+            <small>保存</small><br />
           </el-col>
         </el-row>
       </el-card>
     </div>
 
     <div :id="$style.footer">
-      <el-button @click="location.href = 'https://ambidata.io/bd/board.html?id=55252'">
+      <el-button :id="$style.ambient" @click="location.href = 'https://ambidata.io/bd/board.html?id=55252'">
         家事の発生状況を見る
         <el-icon :size="30"><TrendCharts /></el-icon>
       </el-button>
       <el-select :id="$style.lang" v-model="state.lang">
-        <el-option @click="lagnChange" label="JP" value="jp" />
-        <el-option @click="lagnChange" label="EK" value="ek" />
+        <el-option @click="changeLang" label="JP" value="jp" />
+        <el-option @click="changeLang" label="EK" value="ek" />
       </el-select>
     </div>
   </div>
@@ -66,6 +73,16 @@
 <script lang="ts">
 import { defineComponent, reactive } from 'vue';
 import { TrendCharts, UploadFilled, Memo } from '@element-plus/icons-vue';
+
+/**
+ * ex: https://xxx.ngrok.io
+ */
+const ENDPOINT = location.search.split(/api=|&/)[1];
+
+// api client
+import { Client, GetAllRes } from '@/api/client';
+
+// components
 import * as notification from '@/components/notification';
 
 export default defineComponent({
@@ -129,53 +146,86 @@ export default defineComponent({
         },
       },
     });
+    const client = new Client(ENDPOINT);
+
+    if (!ENDPOINT) {
+      notification.error({
+        title: '通信エラー',
+        message:
+          '通信に必要なパラメータがありません。Raspberry Pi 等の画面に表示された QR コードをスキャンしてアクセスしてください。',
+      });
+    }
+
+    const reflectResToState = (res: GetAllRes) => {
+      state.lang = res.lang;
+      state.sensor = res.sensor;
+    };
+
+    (async () => {
+      const res = await client.getAll();
+      reflectResToState(res);
+    })();
 
     const save = () => {
       notification.success({ title: '成功', message: '保存しました' });
     };
 
-    const lagnChange = () => {
+    const changeLang = () => {
       notification.success({ title: '成功', message: `言語を${state.lang}に変更しました` });
     };
 
     return {
       state,
       save,
-      lagnChange,
+      changeLang,
       location,
+      ENDPOINT,
     };
   },
 });
 </script>
 
 <style lang="scss" module>
+$WIDTH: 375px;
+
 #parent {
-  width: 375px;
+  width: $WIDTH;
   margin: 0 auto;
 }
+
 .setting {
-  margin: 30px 0;
+  margin: 40px 0;
 }
+
 .title {
   text-align: left;
   font-weight: bold;
   line-height: 32px;
 }
+
 .input {
   padding: 0 5px;
 }
+
 #footer {
   position: fixed;
-  width: 100%;
-  left: 0;
+  width: $WIDTH;
+  margin: 0 auto;
   bottom: 0;
 }
+
+#ambient {
+  margin-right: 78px;
+}
+
 #lang {
   width: 50px;
 }
+
 .left {
   text-align: left;
 }
+
 .right {
   text-align: right;
 }


### PR DESCRIPTION
## 概要

file db の内容を先日実装した web api で取得(`GET`)し先日実装して頂いた Vue の画面へ渡して表示できるようにしました。
(@strawberinmilk 保存ボタン押したときに `PUT` の api 叩く部分は実装お願いいたします。)
&その他リファクタ実施しました。

## 影響範囲

Vue(スタイルも一部修正)
db 構造(Vue の State に寄せた)
ambient read loop の該当センサ判定コード
api(言語設定変更用を追加実装)
README.md

## 対応内容

- db 構造を修正
- api(言語設定変更用を追加実装)
- api client を実装
- api client を setup 時に呼び db 内容を state へ反映
- vue 側操作性を改善(UI)
- api ENDPOINT が渡されてない場合の表示を実装
- ambient read loop 内の該当センサ判定コードを高階関数でリファクタ
- README.md の修正(誤字脱字)

## チェックリスト

- [x] 実行時エラーが発生していない (node&chrome dev tool)
- [x] スマホで見ても UI が崩れていない

## 該当タスク

プロジェクト管理ツールを使っている場合はその URL など

## キャプチャ

ENDPOINT が渡されてない場合
<img width="974" alt="image" src="https://user-images.githubusercontent.com/18223236/216472176-aeb2f45c-b8df-4684-8106-01aa54f2be05.png">

ENDPOINT が渡された場合
例1: `http://localhost:8080/nameless-housework-notification/?api=https://be22-157-14-246-100.ngrok.io`
例2: `https://nameless-housework.github.io/nameless-housework-notification/?api=https://be22-157-14-246-100.ngrok.io`
<img width="434" alt="image" src="https://user-images.githubusercontent.com/18223236/216472359-58423ff3-9341-43bf-a520-c29a31d4bff6.png">
